### PR TITLE
document help flag

### DIFF
--- a/help.go
+++ b/help.go
@@ -38,6 +38,8 @@ func helpGlobal(e *Engine) {
 	for _, cmd := range cs {
 		e.Writer.Writef(fmt.Sprintf(fmt.Sprintf("<h1>%%-%ds</h1>  <value>%%s</value>\n", l), cmd.FullCommand(), cmd.Description))
 	}
+
+	e.Writer.Writef("\nUse <info>convox [command] --help</info> for more information about a command.\n")
 }
 
 func helpCommand(e *Engine, cmd *Command) {


### PR DESCRIPTION
Document `-h` flag in global help.
```
$ convox
...
convox version              display version information

Use convox [command] --help for more information about a command.
$
```