### PR TITLE
Create SettingDeleteKey to delete specific keys on convox config files

### DIFF
--- a/context.go
+++ b/context.go
@@ -193,6 +193,10 @@ func (c *Context) SettingWriteKey(name, key, value string) error {
 	return c.engine.SettingWriteKey(name, key, value)
 }
 
+func (c *Context) SettingDeleteKey(name, key string) error {
+	return c.engine.SettingDeleteKey(name, key)
+}
+
 func (c *Context) Table(columns ...string) *Table {
 	return &Table{Columns: columns, Context: c}
 }

--- a/setting.go
+++ b/setting.go
@@ -129,6 +129,30 @@ func (e *Engine) SettingWriteKey(name, key, value string) error {
 	return e.SettingWrite(name, string(data))
 }
 
+func (e *Engine) SettingDeleteKey(name, key string) error {
+	s, err := e.SettingRead(name)
+	if err != nil {
+		return err
+	}
+
+	data := []byte(coalesce(s, "{}"))
+
+	var kv map[string]string
+
+	if err := json.Unmarshal(data, &kv); err != nil {
+		return err
+	}
+
+	delete(kv, key)
+
+	data, err = json.MarshalIndent(kv, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return e.SettingWrite(name, string(data))
+}
+
 func (e *Engine) localSettingDir() string {
 	return fmt.Sprintf(".%s", e.Name)
 }


### PR DESCRIPTION
It will be used by V2 CLI to track self managed racks (installed "locally" through the CLI).